### PR TITLE
Fix Helix Token issue

### DIFF
--- a/.github/actions/publisher.js
+++ b/.github/actions/publisher.js
@@ -189,7 +189,7 @@ async function unpublishPage(pagePath, environment) {
     const response = await fetch(`${HELIX_URL}/${environment}/${HLX_ORG}/${HLX_SITE}/main/${pagePath}`, {
       method: 'DELETE',
       headers: {
-        'Authorization': `Bearer ${HELIX_TOKEN}`,
+        'Authorization': `token ${HELIX_TOKEN}`,
         'Accept': 'application/json',
       },
     });
@@ -219,7 +219,7 @@ async function publishPage(pagePath, environment) {
     const response = await fetch(`${HELIX_URL}/${environment}/${HLX_ORG}/${HLX_SITE}/main/${pagePath}`, {
       method: 'POST',
       headers: {
-        'Authorization': `Bearer ${HELIX_TOKEN}`,
+        'Authorization': `token ${HELIX_TOKEN}`,
         'Accept': 'application/json',
       },
     });


### PR DESCRIPTION
Helix tokens use `Authorization: token` not `Authorization: Bearer`.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-block-collection--adobe.hlx.page
- After: https://<branch>--aem-block-collection--adobe.hlx.page
