### PR TITLE
Updates to search tool

### DIFF
--- a/tools/plugins/da-chat/da-chat.js
+++ b/tools/plugins/da-chat/da-chat.js
@@ -695,10 +695,10 @@ class DAChat {
             // Analyze scopes for Admin API compatibility
             if (payload.scope) {
               const scopes = payload.scope.split(',');
+              // eslint-disable-next-line no-unused-vars
               const hasAdminScopes = scopes.some((scope) => scope.includes('read_pc.dma_aem_ams')
                 || scope.includes('admin')
                 || scope.includes('helix'));
-
             }
           }
         } catch (e) {

--- a/tools/search.html
+++ b/tools/search.html
@@ -232,6 +232,15 @@
                   </label>
                 </div>
               </div>
+
+              <div class="input-group">
+                <div class="checkbox-option">
+                  <label class="checkbox-item">
+                    <input type="checkbox" id="find-blank-pages">
+                    <span class="checkbox-label">Find empty pages (no source content)</span>
+                  </label>
+                </div>
+              </div>
               <div class="input-group">
                 <label for="modified-since" class="input-label">
                   <span class="label-text">Modified Since</span>

--- a/tools/search/icons/copy.svg
+++ b/tools/search/icons/copy.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="18" viewBox="0 0 18 18" width="18">
+  <defs>
+    <style>
+      .fill {
+        fill: #464646;
+      }
+    </style>
+  </defs>
+  <title>S Copy 18 N</title>
+  <rect id="Canvas" fill="#ff13dc" opacity="0" width="18" height="18" /><rect class="fill" height="1" rx="0.25" width="1" x="16" y="11" />
+  <rect class="fill" height="1" rx="0.25" width="1" x="16" y="9" />
+  <rect class="fill" height="1" rx="0.25" width="1" x="16" y="7" />
+  <rect class="fill" height="1" rx="0.25" width="1" x="16" y="5" />
+  <rect class="fill" height="1" rx="0.25" width="1" x="16" y="3" />
+  <rect class="fill" height="1" rx="0.25" width="1" x="16" y="1" />
+  <rect class="fill" height="1" rx="0.25" width="1" x="14" y="1" />
+  <rect class="fill" height="1" rx="0.25" width="1" x="12" y="1" />
+  <rect class="fill" height="1" rx="0.25" width="1" x="10" y="1" />
+  <rect class="fill" height="1" rx="0.25" width="1" x="8" y="1" />
+  <rect class="fill" height="1" rx="0.25" width="1" x="6" y="1" />
+  <rect class="fill" height="1" rx="0.25" width="1" x="6" y="3" />
+  <rect class="fill" height="1" rx="0.25" width="1" x="6" y="5" />
+  <rect class="fill" height="1" rx="0.25" width="1" x="6" y="7" />
+  <rect class="fill" height="1" rx="0.25" width="1" x="6" y="9" />
+  <rect class="fill" height="1" rx="0.25" width="1" x="6" y="11" />
+  <rect class="fill" height="1" rx="0.25" width="1" x="8" y="11" />
+  <rect class="fill" height="1" rx="0.25" width="1" x="10" y="11" />
+  <rect class="fill" height="1" rx="0.25" width="1" x="12" y="11" />
+  <rect class="fill" height="1" rx="0.25" width="1" x="14" y="11" />
+  <path class="fill" d="M5,6H1.5a.5.5,0,0,0-.5.5v10a.5.5,0,0,0,.5.5h10a.5.5,0,0,0,.5-.5V13H5.5a.5.5,0,0,1-.5-.5Z" />
+</svg>

--- a/tools/search/search.css
+++ b/tools/search/search.css
@@ -1982,3 +1982,40 @@ input, textarea, select {
 .filters-sidebar .input-field {
   margin-bottom: 0;
 }
+
+/* Blank Page Mode Styling */
+.blank-page-disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transition: opacity 0.2s ease;
+}
+
+.blank-page-mode {
+  position: relative;
+}
+
+.blank-page-mode::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(245, 245, 245, 0.8);
+  pointer-events: none;
+  border-radius: var(--border-radius);
+  z-index: 1;
+  transition: opacity 0.2s ease;
+}
+
+.blank-page-mode .blank-page-disabled {
+  position: relative;
+  z-index: 0;
+}
+
+/* Ensure checkboxes and labels remain clickable */
+.blank-page-mode input[type="checkbox"]:not(.blank-page-disabled),
+.blank-page-mode label:not(.blank-page-disabled) {
+  position: relative;
+  z-index: 2;
+}


### PR DESCRIPTION
Searchtool updates

- allow to find empty source pages and some UI additions
- caching improvements
- update using crawl function native to DA sdk

Test URLs:
- Before: https://main--aem-block-collection--adobe.hlx.page
- After: https://findreplace--aem-block-collection--adobe.hlx.page

can test the app on : https://da.live/app/aemsites/da-blog-tools/tools/search?ref=local
